### PR TITLE
Update protolock file version to 26.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 echo "--2-- $(which javac)"
 echo "--3-- $(readlink -f $( which javac ))"
 
-# Skip proto lock check for development builds (network/proxy issues)
-./mvnw -pl quarkus/deployment,quarkus/dist,themes, -am -DskipTests -DskipProtoLock=true clean install | tee log-$(date +%H-%M-%y-%m-%d).txt
+./mvnw -pl quarkus/deployment,quarkus/dist,themes, -am -DskipTests clean install | tee log-$(date +%H-%M-%y-%m-%d).txt
 
 echo "Running build command for MSQL database"
 

--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -116,7 +116,7 @@
                     </execution>
                 </executions>
                 <configuration combine.self="append">
-                    <remoteLockFiles>https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/release/26.0/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.1/model/infinispan/proto.lock</remoteLockFiles>
+                    <remoteLockFiles>https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.1/model/infinispan/proto.lock</remoteLockFiles>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
## Summary
Updated the proto-schema-compatibility check to reference Keycloak 26.1 release instead of 26.0 for Infinispan protocol buffer schema compatibility validation.

## Changes
- **File**: `model/infinispan/pom.xml`
- **Change**: Updated `remoteLockFiles` configuration in `proto-schema-compatibility-maven-plugin` to use Keycloak 26.1 proto lock file
